### PR TITLE
Touch up mobile navbar, notes/faq links to website

### DIFF
--- a/static/css/visitdata.css
+++ b/static/css/visitdata.css
@@ -37,7 +37,7 @@ h4 {
 
 @media (min-width: 1200px) {
   .main-mobile {
-    padding-top: 50px;
+    padding-top: 60px;
   }
 
   .map-us {
@@ -61,7 +61,7 @@ h4 {
 
 @media (min-width: 990px) and (max-width: 1199px) {
   .main-mobile {
-    padding-top: 50px;
+    padding-top: 60px;
   }
 
   .bd-placeholder-img-lg {
@@ -142,7 +142,7 @@ h4 {
 
 @media (min-width: 430px) and (max-width: 825px) {
   .main-mobile {
-    padding-top: 55px;
+    padding-top: 60px;
   }
 
   .map-us {
@@ -157,7 +157,7 @@ h4 {
 
 @media (max-width: 425px) {
   .main-mobile {
-    padding-top: 100px;
+    padding-top: 130px;
   }
 
   .map-us {

--- a/static/render_cube.js
+++ b/static/render_cube.js
@@ -78,6 +78,8 @@ function drawChart() {
           }
         }]
       }
+    })
+  }
 }
 
 var tableFilters = new Map();

--- a/templates/allstate.html
+++ b/templates/allstate.html
@@ -72,7 +72,7 @@
                   <br/>
                   <li>If data is missing for a particular County or Location Type, that means there weren't enough visits for that Location Type in that County to have usable data.</li>
                   <br/>
-                  <li>If you are a crisis response team who needs help working with this data — please contact support@visitdata.org. VisitData.org needs volunteer programmers, data analysts, and crisis team liaisons — please contact volunteers@visitdata.org or visit https://github.com/dsjoerg/ca_visit_tracking.
+                  <li>If you are a crisis response team who needs help working with this data — please contact support@visitdata.org. VisitData.org needs volunteer programmers, data analysts, and crisis team liaisons — please contact volunteers@visitdata.org or visit https://github.com/VisitData-org/ca_visit_tracking.
                 </ul>
               </div>
               <div class="modal-footer">

--- a/templates/bydate.html
+++ b/templates/bydate.html
@@ -72,7 +72,7 @@
             <br/>
             <li>If data is missing for a particular County or Location Type, that means there weren't enough visits for that Location Type in that County to have usable data.</li>
             <br/>
-            <li>If you are a crisis response team who needs help working with this data — please contact support@visitdata.org. VisitData.org needs volunteer programmers, data analysts, and crisis team liaisons — please contact volunteers@visitdata.org or visit https://github.com/dsjoerg/ca_visit_tracking.
+            <li>If you are a crisis response team who needs help working with this data — please contact support@visitdata.org. VisitData.org needs volunteer programmers, data analysts, and crisis team liaisons — please contact volunteers@visitdata.org or visit https://github.com/VisitData-org/ca_visit_tracking.
           </ul>
         </div>
         <div class="modal-footer">

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -111,7 +111,7 @@
     </div>
     <div id="collapseSeven" class="collapse" aria-labelledby="headingSeven" data-parent="#accordion">
       <div class="card-body">
-        If you are a crisis response team who needs help working with this data — please contact support@visitdata.org. VisitData.org needs volunteer programmers, data analysts, and crisis team liaisons — please contact volunteers@visitdata.org or visit https://github.com/dsjoerg/ca_visit_tracking.
+        If you are a crisis response team who needs help working with this data — please contact support@visitdata.org. VisitData.org needs volunteer programmers, data analysts, and crisis team liaisons — please contact volunteers@visitdata.org or visit https://github.com/VisitData-org/ca_visit_tracking.
       </div>
     </div>
   </div>

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -49,7 +49,7 @@
       <a class="navbar-brand text-light" href="/index.html">VisitData</a>
     </div>
     <div id="navbarNav">
-      <ul class="navbar-nav flex-row">
+      <ul class="navbar-nav flex-row flex-wrap">
         <li class="nav-item pr-3">
           <a class="nav-link text-light" id="nav-chartgrouped" href="/bydate.html">County/Grouped</a>
         </li>


### PR DESCRIPTION
Couple cosmetic changes.
1. track site move to visitdata.org in notes and faq
2. wrap the navbar content on mobile
3. fix cube.html syntax errors
LMK if I should be looking elsewhere for cube html/css.